### PR TITLE
Object oriented fetchAll

### DIFF
--- a/syntax/inc/cache.php
+++ b/syntax/inc/cache.php
@@ -72,7 +72,7 @@ class datatemplate_cache {
         }
         if(!$cachedate || $latest > (int) $cachedate  || isset($_REQUEST['purge'])) {
             $res = $sqlite->query($sql);
-            $rows = sqlite_fetch_all($res, SQLITE_NUM);
+            $rows = $res->fetchAll(SQLITE_NUM);
             file_put_contents($cachefile, serialize($rows), LOCK_EX);
         } else {
             // We arrive here when the cache seems up-to-date. However,


### PR DESCRIPTION
The version with sqlite_fetch_all($res, SQLITE_NUM) did not work in my setup:

PHP 5.3.10
DokuWiki Adora Belle
data plugin released at 2013-02-06

That means, that it always printed "Nothing." instead of the actual list. The call to sqlite_fetch_all returned NULL.

Replacing that one line by the object oriented style $res->fetchAll(SQLITE_NUM) made it work for me.

Hope it doesn't break other installations.
