### PR TITLE
update to method of Helper of Sqlite plugin.

### DIFF
--- a/syntax/inc/cache.php
+++ b/syntax/inc/cache.php
@@ -37,6 +37,7 @@ class datatemplate_cache {
     public function checkAndBuildCache($data, $sql, &$dtlist) {
         global $ID;
         // We know that the datatemplate list has a datahelper.
+        /** @var $sqlite helper_plugin_sqlite */
         $sqlite = $dtlist->dthlp->_getDB();
 
         // Build minimalistic data array for checking the cache
@@ -53,7 +54,7 @@ class datatemplate_cache {
         $dtcc['filter'] = $data['filter'];
         $sqlcc = $dtlist->_buildSQL($dtcc);
         $res = $sqlite->query($sqlcc);
-        $pageids = sqlite_fetch_all($res, SQLITE_NUM);
+        $pageids = $sqlite->res2arr($res, $assoc = false);
 
         // Ask dokuwiki for cache file name
         $cachefile = getCacheName($sql, '.datatemplate');
@@ -72,7 +73,7 @@ class datatemplate_cache {
         }
         if(!$cachedate || $latest > (int) $cachedate  || isset($_REQUEST['purge'])) {
             $res = $sqlite->query($sql);
-            $rows = sqlite_fetch_all($res, SQLITE_NUM);
+            $rows = $sqlite->res2arr($res, $assoc = false);
             file_put_contents($cachefile, serialize($rows), LOCK_EX);
         } else {
             // We arrive here when the cache seems up-to-date. However,

--- a/syntax/inc/cache.php
+++ b/syntax/inc/cache.php
@@ -13,7 +13,7 @@ class datatemplate_cache {
     /**
      * Remove any metadata that might have been stored by previous versions
      * of the plugin.
-     * @param $renderer an instance of the dokuwiki renderer.
+     * @param Doku_Renderer_metadata $renderer an instance of the dokuwiki renderer.
      */
     public function removeMeta(&$renderer) {
         global $ID;
@@ -32,10 +32,9 @@ class datatemplate_cache {
      *
      * @param array $data from the handle function
      * @param string $sql stripped SQL for hash generation
-     * @param reference $dtlist the calling datatemplate list instance
+     * @param syntax_plugin_datatemplate_list $dtlist reference, the calling datatemplate list instance
      */
     public function checkAndBuildCache($data, $sql, &$dtlist) {
-        global $ID;
         // We know that the datatemplate list has a datahelper.
         /** @var $sqlite helper_plugin_sqlite */
         $sqlite = $dtlist->dthlp->_getDB();

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -266,6 +266,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
         global $ID;
         // Add pagination controls
         if($data['limit']){
+            $text = '';
             $params = $this->dthlp->_a2ua('dataflt',$_REQUEST['dataflt']);
             //$params['datasrt'] = $_REQUEST['datasrt'];
             $offset = (int) $_REQUEST['dataofs'];

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -108,7 +108,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
      * Create output
      */
     function render($format, &$R, $data) {
-        global $ID;
+
         if(is_null($data)) return false;
 
         $sql = $this->_buildSQL($data);
@@ -147,7 +147,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
             }
 
             if ($cnt === 0) {
-                $this->nullList($data, $clist, $R);
+                $this->nullList($data, $clist = array(), $R);
                 return true;
             }
 
@@ -169,7 +169,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
      * @param string $wikipage the id of the wikipage containing the template
      * @param array $data output of the handle function
      * @param array $rows the result of the sql query
-     * @param reference $R the dokuwiki renderer
+     * @param Doku_Renderer_xhtml $R the dokuwiki renderer
      * @return boolean Whether the page has been correctly (not: succesfully) processed.
      */
     function _renderTemplate($wikipage, $data, $rows, &$R) {
@@ -264,9 +264,9 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
      */
     function _renderPagination($data, $numrows) {
         global $ID;
+        $text = '';
         // Add pagination controls
         if($data['limit']){
-            $text = '';
             $params = $this->dthlp->_a2ua('dataflt',$_REQUEST['dataflt']);
             //$params['datasrt'] = $_REQUEST['datasrt'];
             $offset = (int) $_REQUEST['dataofs'];
@@ -305,6 +305,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
             }
             return '<div class="prevnext">' . $text . '</div>';
         }
+        return $text;
     }
 
     /**


### PR DESCRIPTION
Update of sqlite2 methods to methods of the Helper of the Sqlite Plugin. This plugin takes care of switching between sqlite2 and sqlite3.
- added also update of PHPDocs of some methods
- remove unused global variable declarations
- declare other variables
- added support for _wiki type (same as no type defined)
