### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -40,7 +40,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
     /**
      * Handle the match - parse the data
      */
-    function handle($match, $state, $pos, Doku_Handler &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         // The parser of the parent class should have nicely parsed all
         // parameters. We want to extract the template parameter and treat
         // it separately.
@@ -63,7 +63,7 @@ class syntax_plugin_datatemplate_entry extends syntax_plugin_data_entry {
     /**
      * Create output or save the data
      */
-    function render($format, Doku_Renderer &$renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data) {
         global $ID;
         switch ($format){
             case 'xhtml':

--- a/syntax/filterform.php
+++ b/syntax/filterform.php
@@ -52,7 +52,7 @@ class syntax_plugin_datatemplate_filterform extends DokuWiki_Syntax_Plugin {
     /**
      * Handler to prepare matched data for the rendering process.
      */
-    function handle($match, $state, $pos, Doku_Handler &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $data = array();
         $lines = explode("\n",$match);
         foreach ( $lines as $num => $line ) {
@@ -72,7 +72,7 @@ class syntax_plugin_datatemplate_filterform extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the actual output creation.
      */
-    function render($mode, Doku_Renderer &$R, $data) {
+    function render($mode, Doku_Renderer $R, $data) {
         if($mode == 'xhtml'){
             /** @var $R Doku_Renderer_xhtml */
             $R->info['cache'] = false;

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -42,7 +42,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
                                         $mode, 'plugin_datatemplate_list');
     }
 
-    function handle($match, $state, $pos, Doku_Handler &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         // We want the parent to handle the parsing, but still accept
         // the "template" paramter. So we need to remove the corresponding
         // line from $match.
@@ -107,7 +107,7 @@ class syntax_plugin_datatemplate_list extends syntax_plugin_data_table {
     /**
      * Create output
      */
-    function render($format, Doku_Renderer &$R, $data) {
+    function render($format, Doku_Renderer $R, $data) {
 
         if(is_null($data)) return false;
 


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
